### PR TITLE
fix cmd output formatting

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -83,7 +84,7 @@ Binaries are dropped into the current working directory.
 				log.Fatalf("error running go test: %s", err)
 			}
 
-			log.Printf("Tests Succeeded!\n\n")
+			fmt.Print("Tests Succeeded!\n\n")
 		}
 
 		err = lang.Build(workDir, meta, branch)
@@ -91,7 +92,7 @@ Binaries are dropped into the current working directory.
 			log.Fatalf("build failed: %s", err)
 		}
 
-		log.Printf("Build Succeeded!\n\n")
+		fmt.Print("Build Succeeded!\n\n")
 
 		err = gomason.HandleArtifacts(meta, workDir, cwd, false, false, true)
 		if err != nil {

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -78,7 +79,7 @@ Publish will upload your binaries to wherever it is you've configured them to go
 				log.Fatalf("error running go test: %s", err)
 			}
 
-			log.Printf("Tests Succeeded!\n\n")
+			fmt.Print("Tests Succeeded!\n\n")
 		}
 
 		err = lang.Build(workDir, meta, branch)
@@ -86,7 +87,7 @@ Publish will upload your binaries to wherever it is you've configured them to go
 			log.Fatalf("build failed: %s", err)
 		}
 
-		log.Printf("Build Succeeded!\n\n")
+		fmt.Print("Build Succeeded!\n\n")
 
 		if meta.PublishInfo.SkipSigning {
 			log.Printf("[DEBUG] Skipping signing due to 'skip-signing': true in metadata.json")

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -80,7 +81,7 @@ Sometimes you need the benefits of a full system here.  Now.  Right at your fing
 			log.Fatalf("error running go test: %s", err)
 		}
 
-		log.Printf("Success!\n\n")
+		fmt.Print("Success!\n\n")
 	},
 }
 

--- a/pkg/gomason/golang.go
+++ b/pkg/gomason/golang.go
@@ -90,7 +90,7 @@ func (Golang) Checkout(gopath string, meta Metadata, branch string) (err error) 
 	err = os.Chdir(codepath)
 
 	if err != nil {
-		log.Printf("Error changing working dir to %q: %s", codepath, err)
+		log.Printf("[ERROR] changing working dir to %q: %s", codepath, err)
 		return err
 	}
 
@@ -154,18 +154,18 @@ func (Golang) Prep(gopath string, meta Metadata) (err error) {
 
 // Test Runs 'go test -v ./...' in the checked out code directory
 func (Golang) Test(gopath string, gomodule string) (err error) {
-	wd := fmt.Sprintf("%s/src/%s", gopath, gomodule)
+	wd := filepath.Join(gopath, "src", gomodule)
 
 	log.Printf("[DEBUG] Changing working directory to %s.\n", wd)
 
 	err = os.Chdir(wd)
 
 	if err != nil {
-		log.Printf("Error changing working dir to %q: %s", wd, err)
+		log.Printf("[ERROR] changing working dir to %q: %s", wd, err)
 		return err
 	}
 
-	log.Printf("[DEBUG] Running 'go test -v ./...'.\n\n")
+	log.Print("[DEBUG] Running 'go test -v ./...'.\n\n")
 
 	cmd := exec.Command("go", "test", "-v", "./...")
 
@@ -176,9 +176,9 @@ func (Golang) Test(gopath string, gomodule string) (err error) {
 
 	output, err := cmd.CombinedOutput()
 
-	log.Printf(string(output))
+	fmt.Print(string(output))
 
-	log.Printf("[DEBUG] Done with go test.\n\n")
+	log.Print("[DEBUG] Done with go test.\n\n")
 
 	return err
 }
@@ -211,7 +211,7 @@ func (g Golang) Build(gopath string, meta Metadata, branch string) (err error) {
 	err = os.Chdir(wd)
 
 	if err != nil {
-		log.Printf("Error changing working dir to %q: %s", wd, err)
+		log.Printf("[ERROR] changing working dir to %q: %s", wd, err)
 		return err
 	}
 
@@ -263,10 +263,10 @@ func (g Golang) Build(gopath string, meta Metadata, branch string) (err error) {
 
 		out, err := cmd.CombinedOutput()
 
-		log.Printf("%s\n", string(out))
+		fmt.Printf("%s\n", string(out))
 
 		if err != nil {
-			log.Printf("Build error: %s\n", err.Error())
+			log.Printf("[ERROR] Build error: %s\n", err.Error())
 			return err
 		}
 


### PR DESCRIPTION
For output that doesn't need to be guarded by logging levels, we should
use fmt.Print