### PR TITLE
Removed redundant branch argument to Build(), and checks for metadata…

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -87,7 +87,7 @@ Binaries are dropped into the current working directory.
 			fmt.Print("Tests Succeeded!\n\n")
 		}
 
-		err = lang.Build(workDir, meta, branch)
+		err = lang.Build(workDir, meta)
 		if err != nil {
 			log.Fatalf("build failed: %s", err)
 		}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -82,7 +82,7 @@ Publish will upload your binaries to wherever it is you've configured them to go
 			fmt.Print("Tests Succeeded!\n\n")
 		}
 
-		err = lang.Build(workDir, meta, branch)
+		err = lang.Build(workDir, meta)
 		if err != nil {
 			log.Fatalf("build failed: %s", err)
 		}

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -80,7 +80,7 @@ Signing sorta implies something to sign, which in turn, implies that it built, w
 
 		log.Printf("Tests Succeeded!\n\n")
 
-		err = lang.Build(workDir, meta, branch)
+		err = lang.Build(workDir, meta)
 		if err != nil {
 			log.Fatalf("build failed: %s", err)
 		}

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.8",
+  "version": "2.6.0",
   "package": "github.com/nikogura/gomason",
   "description": "A tool for testing, building, signing, and publishing your project from a clean workspace.",
   "repository": "http://localhost:8081/artifactory/generic-local",

--- a/pkg/gomason/golang.go
+++ b/pkg/gomason/golang.go
@@ -184,7 +184,7 @@ func (Golang) Test(gopath string, gomodule string) (err error) {
 }
 
 // Build uses `gox` to build binaries per metadata.json
-func (g Golang) Build(gopath string, meta Metadata, branch string) (err error) {
+func (g Golang) Build(gopath string, meta Metadata) (err error) {
 	log.Print("[DEBUG] Checking to see that gox is installed.\n")
 
 	// Install gox if it's not already there
@@ -196,13 +196,13 @@ func (g Golang) Build(gopath string, meta Metadata, branch string) (err error) {
 		}
 	}
 
-	if _, err := os.Stat(fmt.Sprintf("%s/src/%s/metadata.json", gopath, meta.Package)); os.IsNotExist(err) {
-		err = g.Checkout(gopath, meta, branch)
-		if err != nil {
-			err = errors.Wrap(err, fmt.Sprintf("Failed to checkout module: %s branch: %s ", meta.Package, branch))
-			return err
-		}
-	}
+	//if _, err := os.Stat(fmt.Sprintf("%s/src/%s/metadata.json", gopath, meta.Package)); os.IsNotExist(err) {
+	//	err = g.Checkout(gopath, meta, branch)
+	//	if err != nil {
+	//		err = errors.Wrap(err, fmt.Sprintf("Failed to checkout module: %s branch: %s ", meta.Package, branch))
+	//		return err
+	//	}
+	//}
 
 	wd := fmt.Sprintf("%s/src/%s", gopath, meta.Package)
 

--- a/pkg/gomason/golang_test.go
+++ b/pkg/gomason/golang_test.go
@@ -144,7 +144,6 @@ func TestBuild(t *testing.T) {
 	}
 
 	gomodule := testMetadataObj().Package
-	branch := "master"
 
 	log.Printf("Checking out Master Branch")
 
@@ -166,7 +165,7 @@ func TestBuild(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = lang.Build(gopath, testMetadataObj(), branch)
+	err = lang.Build(gopath, testMetadataObj())
 	if err != nil {
 		log.Printf("Error building: %s", err)
 		t.FailNow()
@@ -228,7 +227,7 @@ func TestTest(t *testing.T) {
 }
 
 func TestSignVerifyBinary(t *testing.T) {
-	os.Setenv(NO_USER_CONFIG_ENV, "true")
+	_ = os.Setenv(NO_USER_CONFIG_ENV, "true")
 	shellCmd, err := exec.LookPath("gpg")
 	if err != nil {
 		log.Printf("Failed to check if gpg is installed:%s", err)
@@ -248,11 +247,9 @@ func TestSignVerifyBinary(t *testing.T) {
 
 	meta.Repository = fmt.Sprintf("http://localhost:%d/repo/tool", servicePort)
 
-	branch := "master"
-
 	// build artifacts
 	log.Printf("Running Build\n")
-	err = lang.Build(gopath, meta, branch)
+	err = lang.Build(gopath, meta)
 	if err != nil {
 		log.Printf("Error building: %s", err)
 		t.FailNow()

--- a/pkg/gomason/languages.go
+++ b/pkg/gomason/languages.go
@@ -12,37 +12,37 @@ const (
 // Language is a generic interface for doing what gomason does - abstracting build, test, signing, and publishing of binaries
 type Language interface {
 	CreateWorkDir(string) (string, error)
-	Checkout(string, Metadata, string) error
-	Prep(string, Metadata) error
-	Test(string, string) error
-	Build(string, Metadata, string) error
+	Checkout(workdir string, meta Metadata, branch string) error
+	Prep(workdir string, meta Metadata) error
+	Test(workdir string, module string) error
+	Build(workdir string, meta Metadata) error
 }
 
 // NoLanguage essentially an abstract class for the Language interface
 type NoLanguage struct{}
 
 // CreateWorkDir Stub for the CreateWorkDir action
-func (NoLanguage) CreateWorkDir(string) (string, error) {
-	return "", nil
+func (NoLanguage) CreateWorkDir(string) (workdir string, err error) {
+	return workdir, err
 }
 
 // Checkout Stub for the Checkout action
-func (NoLanguage) Checkout(string, Metadata, string) error {
+func (NoLanguage) Checkout(workdir string, meta Metadata, branch string) error {
 	return nil
 }
 
 // Prep stub for the Prep action
-func (NoLanguage) Prep(string, Metadata) error {
+func (NoLanguage) Prep(workdir string, meta Metadata) error {
 	return nil
 }
 
 // Test Stub for the Test action
-func (NoLanguage) Test(string, string) error {
+func (NoLanguage) Test(workdir string, module string) error {
 	return nil
 }
 
 // Build Stub for the Build Action
-func (NoLanguage) Build(string, Metadata, string) error {
+func (NoLanguage) Build(workdor string, meta Metadata) error {
 	return nil
 }
 

--- a/pkg/gomason/languages_test.go
+++ b/pkg/gomason/languages_test.go
@@ -22,7 +22,7 @@ func TestNoLanguage(t *testing.T) {
 	err = nl.Test("", "")
 	assert.True(t, err == nil, "Test returned an error")
 
-	err = nl.Build("", Metadata{}, "")
+	err = nl.Build("", Metadata{})
 	assert.True(t, err == nil, "Build returned an error")
 
 }


### PR DESCRIPTION
… in golang Build().  Branch is selected by Checkout().  Any other use appears to be redundant.